### PR TITLE
fix: Use generic iOS Simulator destination for GitHub Actions compati…

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,7 +32,7 @@ platform :ios do
       xcodebuild(
         scheme: "template",
         configuration: "Debug",
-        destination: "platform=iOS Simulator,name=iPhone 16",
+        destination: "generic/platform=iOS Simulator",
         xcargs: "PRODUCT_BUNDLE_IDENTIFIER=com.ios.template.stg CODE_SIGNING_ALLOWED=NO",
         build: true
       )
@@ -58,7 +58,7 @@ platform :ios do
       xcodebuild(
         scheme: "template",
         configuration: "Release",
-        destination: "platform=iOS Simulator,name=iPhone 16",
+        destination: "generic/platform=iOS Simulator",
         xcargs: "PRODUCT_BUNDLE_IDENTIFIER=com.ios.template CODE_SIGNING_ALLOWED=NO",
         build: true
       )


### PR DESCRIPTION
…bility

🔧 Fixed GitHub Actions iOS Simulator Issue:
• Changed from 'platform=iOS Simulator,name=iPhone 16' to 'generic/platform=iOS Simulator' • GitHub Actions environment doesn't have iPhone 16 simulator available • Generic destination works with any available iOS Simulator in CI environment • Resolves 'Unable to find destination matching iPhone 16' error in staging workflow

✅ GitHub Actions Compatibility:
• Uses generic/platform=iOS Simulator for reliable CI builds • No dependency on specific simulator device names • Works with whatever iOS Simulator is available in GitHub Actions • Eliminates exit code 70 errors from destination mismatch

🚀 CI/CD Pipeline:
• Staging workflow will now build successfully
• Production workflow will use same reliable destination • No more simulator availability issues in GitHub Actions • Template project ready for automated deployment

📱 Destination Strategy:
• Local development: Can use any available simulator • GitHub Actions: Uses generic iOS Simulator destination • Consistent build process across environments
• No simulator-specific dependencies